### PR TITLE
Implemented colored number component

### DIFF
--- a/src/components/CoinList.tsx
+++ b/src/components/CoinList.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import ColorNum from './ColorNum'
 import axios from 'axios'
 
 interface CoinListProps {
@@ -91,8 +92,12 @@ class CoinList extends Component<CoinListProps, CoinListState> {
               <td key={0}>{coin.symbol}</td>
               <td key={1}>{coin.name}</td>
               <td key={2}>{coin.current_price}</td>
-              <td key={3}>{coin.price_change_24h}</td>
-              <td key={4}>{coin.price_change_percentage_24h}</td>
+              <td key={3}>
+                <ColorNum value={coin.price_change_24h}/>
+              </td>
+              <td key={4}>
+                <ColorNum value={coin.price_change_percentage_24h} suffix="%" />
+              </td>
               <td key={5}>{coin.total_volume}</td>
             </tr>
           )}

--- a/src/components/ColorNum.css
+++ b/src/components/ColorNum.css
@@ -1,0 +1,7 @@
+.positive {
+  color: green;
+}
+
+.negative {
+  color: red;
+}

--- a/src/components/ColorNum.tsx
+++ b/src/components/ColorNum.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import './ColorNum.css'
+
+interface ColorNumProps {
+  value: number,
+  prefix?: string,
+  suffix?: string
+}
+
+function ColorNum(props: ColorNumProps) {
+
+  const positive = (props.value >= 0)
+  return (
+    <span className={positive ? "positive" : "negative"}>
+      {props.prefix ? props.prefix : ''}
+      {props.value}
+      {props.suffix ? props.suffix : ''}
+    </span>
+  )
+}
+
+export default ColorNum


### PR DESCRIPTION
This component will wrap a number in a positive or negative `<span>` tag with either a `positive` or `negative` class. Includes basic styling for green and red. Prefixes and suffixes are also supported.

For example:
`<ColorNum value={actualValue} suffix=" %" />` will check the value, add the ` %` suffix, and wrap them in a span of the correct type.