### PR TITLE
Style candlestick

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,3 +34,7 @@ body {
 .navbar-custom .navbar-nav .nav-link:hover {
   color: var(--highlight);
 }
+
+.apexcharts-menu {
+  color: var(--darker);
+}

--- a/src/components/CandleStick.tsx
+++ b/src/components/CandleStick.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import Chart from "react-apexcharts";
 import ApexCharts from "apexcharts"
-import ApexOptions from "apexcharts"
+import { ApexOptions } from "apexcharts"
 import axios from "axios";
 
 
@@ -23,6 +23,7 @@ interface CoinCandlestickProps {
 interface CandlestickState {
   // options: ApexOptions,
   series: ApexAxisChartSeries,
+  options: ApexOptions
   loaded: boolean
 }
 
@@ -34,6 +35,43 @@ class CoinCandlestick extends Component<CoinCandlestickProps, CandlestickState> 
       series: [{
         data: []
       }],
+      options: {
+        chart: {type:'candlestick'},
+        // title: {
+        //   text: "CandleStick Chart",
+        //   align: "left",
+        // },
+        grid: {
+          borderColor: '#8cc8ff'  // bright
+        },
+        plotOptions: {
+          candlestick: {
+            colors: {
+              upward: "#00dd00",  // bright green
+              downward: "#ff3333",  // red
+            },
+          },
+        },
+        tooltip: {
+          theme: 'dark'
+        },
+        xaxis: {
+          type: 'datetime',
+          labels: {
+            style: {
+              colors: '#d7ecff'  // brighter
+            }
+          }
+        },
+        yaxis: {
+          labels: {
+            style: {
+              colors: '#d7ecff'  // brighter
+            }
+          }
+        }
+      },
+      
       loaded: false
     };
   }
@@ -76,26 +114,7 @@ class CoinCandlestick extends Component<CoinCandlestickProps, CandlestickState> 
     return (
       <div className="candlestick">
         <Chart
-          // options={this.state.option}
-          options={{
-            chart: {type:'candlestick'},
-            // title: {
-            //   text: "CandleStick Chart",
-            //   align: "left",
-            // },
-            theme:{mode: 'dark',},
-            xaxis: {
-              type: "datetime",
-            },
-            plotOptions: {
-              candlestick: {
-                colors: {
-                  upward: "#17b861",
-                  downward: "#e8503a",
-                },
-              },
-            },
-          }}
+          options={this.state.options}
           series={this.state.series}
           type="candlestick"
         />

--- a/src/components/CandleStick.tsx
+++ b/src/components/CandleStick.tsx
@@ -11,6 +11,7 @@ import axios from "axios";
  * Props: id:<string>  id of coin
  *        currancy:<string>  Optional currancy, defaults to usd. 
  *                           If default used, it is not changeable
+ *        title:<string>     Optional title, Default no title
  * Will fill parent container
  */
 
@@ -18,6 +19,7 @@ import axios from "axios";
 interface CoinCandlestickProps { 
   currency?: string,
   id: string
+  title?: string
 }
 
 interface CandlestickState {
@@ -37,10 +39,17 @@ class CoinCandlestick extends Component<CoinCandlestickProps, CandlestickState> 
       }],
       options: {
         chart: {type:'candlestick'},
-        // title: {
-        //   text: "CandleStick Chart",
-        //   align: "left",
-        // },
+        title: {
+          text: this.props.title,
+          align: "left",
+          offsetY: 11,
+          offsetX: 8,
+          style: {
+            fontSize: '1rem',
+            fontWeight: 'bold',
+            color: '#d7ecff',
+          }
+        },
         grid: {
           borderColor: '#8cc8ff'  // bright
         },


### PR DESCRIPTION
Closing Issue candlestick style #35
changed colors,  due to Apexcharts current setup most color and background colors must be set in options and can not use the css var settings.  All settings will be commented with the color name in App.css.  Any global color changes that can be set in css and that affect all charts are in App.css 

Added option title prop

Also fixed option kludge.