### PR TITLE
Reworked coins page Trending and CoinList components to handle mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/node": "^15.3.0",
         "@types/react": "^17.0.5",
         "@types/react-dom": "^17.0.5",
-        "apexcharts": "^3.26.3",
+        "apexcharts": "ekhmoi/apexcharts.js",
         "axios": "^0.21.1",
         "bootstrap": "^5.0.0",
         "express": "^4.17.1",
@@ -3825,9 +3825,9 @@
       }
     },
     "node_modules/apexcharts": {
-      "version": "3.26.3",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.26.3.tgz",
-      "integrity": "sha512-zbP7RBBV2CGffoVMIuTCUG64YbEUzV8IIT7iNVLMtY/OAVXTjPksDxSqKIniTvgJoscKe6sx4P56qDpBSU19VA==",
+      "version": "3.26.0",
+      "resolved": "git+ssh://git@github.com/ekhmoi/apexcharts.js.git#02ad891b2c5ce77d812007c60f7770664581cd97",
+      "license": "MIT",
       "dependencies": {
         "svg.draggable.js": "^2.2.2",
         "svg.easing.js": "^2.0.0",
@@ -25152,9 +25152,8 @@
       }
     },
     "apexcharts": {
-      "version": "3.26.3",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.26.3.tgz",
-      "integrity": "sha512-zbP7RBBV2CGffoVMIuTCUG64YbEUzV8IIT7iNVLMtY/OAVXTjPksDxSqKIniTvgJoscKe6sx4P56qDpBSU19VA==",
+      "version": "git+ssh://git@github.com/ekhmoi/apexcharts.js.git#02ad891b2c5ce77d812007c60f7770664581cd97",
+      "from": "apexcharts@ekhmoi/apexcharts.js",
       "requires": {
         "svg.draggable.js": "^2.2.2",
         "svg.easing.js": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-bootstrap-validation": "^0.1.11",
         "react-dom": "^17.0.2",
         "react-image": "^4.0.3",
+        "react-perfect-scrollbar": "^1.5.8",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
         "typescript": "^4.2.4",
@@ -14460,6 +14461,11 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/perfect-scrollbar": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.1.tgz",
+      "integrity": "sha512-MrSImINnIh3Tm1hdPT6bji6fmIeRorVEegQvyUnhqko2hDGTHhmjPefHXfxG/Jb8xVbfCwgmUIlIajERGXjVXQ=="
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -16512,6 +16518,19 @@
       "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/react-perfect-scrollbar": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/react-perfect-scrollbar/-/react-perfect-scrollbar-1.5.8.tgz",
+      "integrity": "sha512-bQ46m70gp/HJtiBOF3gRzBISSZn8FFGNxznTdmTG8AAwpxG1bJCyn7shrgjEvGSQ5FJEafVEiosY+ccER11OSA==",
+      "dependencies": {
+        "perfect-scrollbar": "^1.5.0",
+        "prop-types": "^15.6.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.3",
+        "react-dom": ">=16.3.3"
       }
     },
     "node_modules/react-property": {
@@ -33390,6 +33409,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "perfect-scrollbar": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.1.tgz",
+      "integrity": "sha512-MrSImINnIh3Tm1hdPT6bji6fmIeRorVEegQvyUnhqko2hDGTHhmjPefHXfxG/Jb8xVbfCwgmUIlIajERGXjVXQ=="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -35054,6 +35078,15 @@
             "regenerator-runtime": "^0.13.4"
           }
         }
+      }
+    },
+    "react-perfect-scrollbar": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/react-perfect-scrollbar/-/react-perfect-scrollbar-1.5.8.tgz",
+      "integrity": "sha512-bQ46m70gp/HJtiBOF3gRzBISSZn8FFGNxznTdmTG8AAwpxG1bJCyn7shrgjEvGSQ5FJEafVEiosY+ccER11OSA==",
+      "requires": {
+        "perfect-scrollbar": "^1.5.0",
+        "prop-types": "^15.6.1"
       }
     },
     "react-property": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^15.3.0",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.5",
-    "apexcharts": "^3.26.3",
+    "apexcharts": "ekhmoi/apexcharts.js",
     "axios": "^0.21.1",
     "bootstrap": "^5.0.0",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-bootstrap-validation": "^0.1.11",
     "react-dom": "^17.0.2",
     "react-image": "^4.0.3",
+    "react-perfect-scrollbar": "^1.5.8",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "typescript": "^4.2.4",

--- a/src/components/CoinList.css
+++ b/src/components/CoinList.css
@@ -1,6 +1,7 @@
 .coinList {
   background: var(--dark);
   border-radius: 10px;
+  word-break: break-all;
 }
 
 .coinList th {
@@ -21,4 +22,9 @@
 
 .coinList .symbol {
   font-weight: bold;
+}
+
+.coinList a {
+  color: var(--brighter);
+  text-decoration: none;
 }

--- a/src/components/CoinList.tsx
+++ b/src/components/CoinList.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { Link } from 'react-router-dom'
 import ColorNum from './ColorNum'
 import SimpleNum from './SimpleNum'
 import axios from 'axios'
@@ -93,19 +94,27 @@ class CoinList extends Component<CoinListProps, CoinListState> {
           <tbody>
             <tr key={0}>
               <th key={0}>Symbol</th>
-              <th key={1}>Name</th>
+              <th key={1} className="d-none d-sm-table-cell">Name</th>
               <th key={2}>Price</th>
-              <th key={3}>24h change</th>
+              <th key={3}  className="d-none d-md-table-cell">24h change</th>
               <th key={4}>24h change %</th>
               <th key={5}>Volume</th>
-              <th key={6}>Trending</th>
+              <th key={6} className="d-none d-lg-table-cell">Trending</th>
             </tr>
             {coins.map((coin, i) => 
               <tr key={i+1}>
-                <td key={0} className="symbol">{coin.symbol.toUpperCase()}</td>
-                <td key={1}>{coin.name}</td>
+                <td key={0} className="symbol">
+                  <Link to={"/coin/" + coin.id}>
+                    {coin.symbol.toUpperCase()}
+                  </Link>
+                </td>
+                <td key={1} className="d-none d-sm-table-cell">
+                  <Link to={"/coin/" + coin.id}>
+                    {coin.name}
+                  </Link>
+                </td>
                 <td key={2}>{coin.current_price}</td>
-                <td key={3}>
+                <td key={3} className="d-none d-md-table-cell">
                   <ColorNum value={coin.price_change_24h}/>
                 </td>
                 <td key={4}>
@@ -113,7 +122,7 @@ class CoinList extends Component<CoinListProps, CoinListState> {
                 </td>
                 <td key={5}><SimpleNum value={coin.total_volume} /></td>
                 
-                <td key={6}><SparkLineChart price={coin.sparkline_in_7d.price} /></td>
+                <td key={6} className="d-none d-lg-table-cell"><SparkLineChart price={coin.sparkline_in_7d.price} /></td>
               </tr>
             )}
           </tbody>

--- a/src/components/Trending.css
+++ b/src/components/Trending.css
@@ -1,14 +1,17 @@
 .trending {
   display: flex;
   gap: 1em;
-  margin: 0 0 1em 0;
-  overflow-x: hidden;
+  margin: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .trending-coin {
   background: var(--dark);
   border-radius: 10px;
   color: var(--brighter);
+  flex: 1;
+  margin-bottom: 1em;
   position: relative;
   padding: 1em 1em 1.5em 1em;
   text-decoration: none;

--- a/src/components/Trending.tsx
+++ b/src/components/Trending.tsx
@@ -1,7 +1,9 @@
 import React, { Component } from 'react'
 import { Link, useHistory } from 'react-router-dom'
+import PerfectScrollbar from 'react-perfect-scrollbar'
 import axios from 'axios'
 import './Trending.css'
+import 'react-perfect-scrollbar/dist/css/styles.css'
 
 const NUM_TRENDING_TO_SHOW = 7
 
@@ -58,18 +60,18 @@ class Trending extends Component<TrendingProps, TrendingState> {
     const { loaded, trending } = this.state
     if (loaded) {
       return (
-        <div className="trending">
-          {trending.slice(0, NUM_TRENDING_TO_SHOW).map((coin, i) =>
-            <Link className="trending-coin" key={i} to={"/coin/" + coin.id}>
-              <img key="image" src={coin.large} alt={coin.name + " logo"}/>
-              <div key="name" className="name">{coin.name}</div>
-              <div key="symbol" className="symbol">{coin.symbol}</div>
-              <div key="price">{coin.price_btc.toFixed(10)} BTC</div>
-              <div key="market-cap"><span className="label">MC rank: </span>{coin.market_cap_rank}</div>
-              <div key="link" className="link">&#8964;</div>
-            </Link>
-          )}
-        </div>
+          <PerfectScrollbar className="trending">
+            {trending.slice(0, NUM_TRENDING_TO_SHOW).map((coin, i) =>
+              <Link className="trending-coin" key={i} to={"/coin/" + coin.id}>
+                <img key="image" src={coin.large} alt={coin.name + " logo"}/>
+                <div key="name" className="name">{coin.name}</div>
+                <div key="symbol" className="symbol">{coin.symbol}</div>
+                <div key="price">{coin.price_btc.toFixed(10)} BTC</div>
+                <div key="market-cap"><span className="label">MC rank: </span>{coin.market_cap_rank}</div>
+                <div key="link" className="link">&#8964;</div>
+              </Link>
+            )}
+          </PerfectScrollbar>
       )
     } else {
       return (


### PR DESCRIPTION
Things to check:
- Trending coins now stretch to fill screen
- Trending coins is scrollable in both desktop and mobile (actual phone) views
- Table coin symbol and name both link to their respective coin detail page
- A number of table columns are hidden at various widths to keep things pretty.
- In extreme cases text will now wrap

Issues:
- In firefox I was getting ApexChart errors from the coin detail page's candlestick chart. It is a known issue which someone has patched in their own fork. I changed out the apexcharts package for his, which fixed the issue.