### PR TITLE
Made coin description links into more visible color. Edited app title and description.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="A cryptocurrency dashboard powered by React and data from CoinGecko API"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Cryptogether</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/CoinDetail.css
+++ b/src/components/CoinDetail.css
@@ -382,3 +382,7 @@
     padding: 1em;
   }
 }
+
+.coin-detail-container .content a {
+  color: var(--highlight);
+}


### PR DESCRIPTION
See ethereum coin for an example with description links.
http://localhost:3000/coin/ethereum
Title is visible in tab name. Description in preview links, like those in discord.
Closes #58 