### PR TITLE
Added content-security-policy to header allowing connections to coingecko

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="A cryptocurrency dashboard powered by React and data from CoinGecko API"
     />
+    <meta http-equiv="Content-Security-Policy" content="connect-src 'self' https://api.coingecko.com" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
You should now be able to visit the app deployed on my server at http://dev.hypersweet.com/cryptogether/ without any console error messages on desktop browsers. Tested Firefox and Chrome with no issue.